### PR TITLE
リレーの配送に失敗する為、右クリック禁止の連合への送信を停止

### DIFF
--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -480,7 +480,8 @@ export class ApRendererService {
 			attachment: files.map(x => this.renderDocument(x)),
 			sensitive: note.cw != null || files.some(file => file.isSensitive),
 			tag,
-			disableRightClick: note.disableRightClick,
+			/* FIXME: これを送信するとリレーでの投稿の配送に失敗する */
+			//disableRightClick: note.disableRightClick,
 			...asDeleteAt,
 			...asEvent,
 			...asPoll,


### PR DESCRIPTION
多分理由としては適切なContextが無いから

なぜ通常投稿に成功してリレーだけ失敗するのかは不明