### PR TITLE
ライフ表示とゲームオーバー処理の改善

### DIFF
--- a/packages/frontend/src/pages/drop-and-fusion.game.vue
+++ b/packages/frontend/src/pages/drop-and-fusion.game.vue
@@ -41,18 +41,21 @@ SPDX-License-Identifier: AGPL-3.0-only
 						<MkButton inline small @click="hold">{{ i18n.ts._bubbleGame.hold }}</MkButton>
 						<img v-if="holdingStock" :src="getTextureImageUrl(holdingStock.mono)" style="width: 32px; margin-left: 8px; vertical-align: bottom;"/>
 					</div>
-					<div class="_woodenFrameInner" :class="$style.stock" style="text-align: center;">
-						<TransitionGroup
-							:enterActiveClass="$style.transition_stock_enterActive"
-							:leaveActiveClass="$style.transition_stock_leaveActive"
-							:enterFromClass="$style.transition_stock_enterFrom"
-							:leaveToClass="$style.transition_stock_leaveTo"
-							:moveClass="$style.transition_stock_move"
-						>
-							<img v-for="x in stock" :key="x.id" :src="getTextureImageUrl(x.mono)" style="width: 32px; vertical-align: bottom;"/>
-						</TransitionGroup>
-					</div>
-				</div>
+                                        <div class="_woodenFrameInner" :class="$style.stock" style="text-align: center;">
+                                                <TransitionGroup
+                                                        :enterActiveClass="$style.transition_stock_enterActive"
+                                                        :leaveActiveClass="$style.transition_stock_leaveActive"
+                                                        :enterFromClass="$style.transition_stock_enterFrom"
+                                                        :leaveToClass="$style.transition_stock_leaveTo"
+                                                        :moveClass="$style.transition_stock_move"
+                                                >
+                                                        <img v-for="x in stock" :key="x.id" :src="getTextureImageUrl(x.mono)" style="width: 32px; vertical-align: bottom;"/>
+                                                </TransitionGroup>
+                                        </div>
+                                        <div class="_woodenFrameInner" style="white-space: nowrap;">
+                                                {{ i18n.ts._bubbleGame.life ?? 'Life' }}: <MkNumber :value="lives"/>
+                                        </div>
+                                </div>
 			</div>
 
 			<div ref="containerEl" :class="[$style.gameContainer, { [$style.gameOver]: isGameOver && !replaying }]" @contextmenu.stop.prevent @click.stop.prevent="onClick" @touchmove.stop.prevent="onTouchmove" @touchend="onTouchend" @mousemove="onMousemove">
@@ -137,10 +140,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<div style="display: flex;">
 				<div class="_woodenFrame" style="flex: 1; margin-right: 10px;">
 					<div class="_woodenFrameInner">
-						<div>{{ i18n.ts._bubbleGame._score.score }}: <MkNumber :value="score"/>{{ getScoreUnit(gameMode) }}</div>
-						<div>{{ i18n.ts._bubbleGame._score.highScore }}: <b v-if="highScore"><MkNumber :value="highScore"/>{{ getScoreUnit(gameMode) }}</b><b v-else>-</b></div>
-						<div v-if="gameMode === 'yen'">
-							{{ i18n.ts._bubbleGame._score.scoreYen }}:
+                                                <div>{{ i18n.ts._bubbleGame._score.score }}: <MkNumber :value="score"/>{{ getScoreUnit(gameMode) }}</div>
+                                                <div>{{ i18n.ts._bubbleGame._score.highScore }}: <b v-if="highScore"><MkNumber :value="highScore"/>{{ getScoreUnit(gameMode) }}</b><b v-else>-</b></div>
+                                                <div v-if="gameMode === 'yen'">
+                                                        {{ i18n.ts._bubbleGame._score.scoreYen }}:
 							<I18n :src="i18n.ts._bubbleGame._score.yen" tag="b">
 								<template #yen><MkNumber :value="yenTotal ?? score"/></template>
 							</I18n>
@@ -577,6 +580,7 @@ const comboPrev = ref(0);
 const maxCombo = ref(0);
 const dropReady = ref(true);
 const isGameOver = ref(false);
+const lives = ref(3);
 const gameLoaded = ref(false);
 const readyGo = ref<'ready' | 'go' | null>('ready');
 const highScore = ref<number | null>(null);
@@ -788,10 +792,11 @@ function reset() {
 	replayPlaybackRate.value = 1;
 	currentPick.value = null;
 	dropReady.value = true;
-	stock.value = [];
-	holdingStock.value = null;
-	score.value = 0;
-	combo.value = 0;
+        stock.value = [];
+        holdingStock.value = null;
+        score.value = 0;
+        lives.value = 3;
+        combo.value = 0;
 	comboPrev.value = 0;
 	maxCombo.value = 0;
 	gameLoaded.value = false;
@@ -953,10 +958,14 @@ function attachGameEvents() {
 		combo.value = value;
 	});
 
-	game.addListener('changeStock', value => {
-		currentPick.value = JSON.parse(JSON.stringify(value[0]));
-		stock.value = JSON.parse(JSON.stringify(value.slice(1)));
-	});
+        game.addListener('changeStock', value => {
+                currentPick.value = JSON.parse(JSON.stringify(value[0]));
+                stock.value = JSON.parse(JSON.stringify(value.slice(1)));
+        });
+
+        game.addListener('changeLives', value => {
+                lives.value = value;
+        });
 
 	game.addListener('changeHolding', value => {
 		holdingStock.value = value;

--- a/packages/misskey-bubble-game/src/game.ts
+++ b/packages/misskey-bubble-game/src/game.ts
@@ -352,7 +352,6 @@ export class DropAndFusionGame extends EventEmitter<{
        }
 
        private finalizeGameOver() {
-               this.removeOverflowBodies();
                this.isGameOver = true;
                this.emit('gameOver');
        }

--- a/packages/misskey-bubble-game/src/game.ts
+++ b/packages/misskey-bubble-game/src/game.ts
@@ -40,8 +40,9 @@ export class DropAndFusionGame extends EventEmitter<{
 	dropped: (x: number) => void;
 	fusioned: (x: number, y: number, nextMono: Mono | null, scoreDelta: number) => void;
 	collision: (energy: number, bodyA: Matter.Body, bodyB: Matter.Body) => void;
-	monoAdded: (mono: Mono) => void;
-	gameOver: () => void;
+        monoAdded: (mono: Mono) => void;
+        changeLives: (lives: number) => void;
+        gameOver: () => void;
 }> {
 	private PHYSICS_QUALITY_FACTOR = 16; // 低いほどパフォーマンスが高いがガタガタして安定しなくなる、逆に高すぎても何故か不安定になる
 	private COMBO_INTERVAL = 60; // frame
@@ -56,8 +57,9 @@ export class DropAndFusionGame extends EventEmitter<{
 	public frame = 0;
 	public engine: Matter.Engine;
 	private tickCallbackQueue: { frame: number; callback: () => void; }[] = [];
-	private overflowCollider: Matter.Body;
-	private isGameOver = false;
+        private overflowCollider: Matter.Body;
+        private isGameOver = false;
+        private _lives = 3;
 	private gameMode: 'normal' | 'yen' | 'square' | 'sweets' | 'space';
 	private rng: () => number;
 	private logs: Log[] = [];
@@ -99,14 +101,22 @@ export class DropAndFusionGame extends EventEmitter<{
 		this.emit('changeCombo', value);
 	}
 
-	private _score = 0;
-	private get score() {
-		return this._score;
-	}
-	private set score(value: number) {
-		this._score = value;
-		this.emit('changeScore', value);
-	}
+        private _score = 0;
+        private get score() {
+                return this._score;
+        }
+        private set score(value: number) {
+                this._score = value;
+                this.emit('changeScore', value);
+        }
+
+        private get lives() {
+                return this._lives;
+        }
+        private set lives(value: number) {
+                this._lives = value;
+                this.emit('changeLives', value);
+        }
 
 	private getMonoRenderOptions: null | ((mono: Mono) => Partial<Matter.IBodyRenderOptions>) = null;
 
@@ -300,34 +310,57 @@ export class DropAndFusionGame extends EventEmitter<{
 		for (const pairs of event.pairs) {
 			const { bodyA, bodyB } = pairs;
 
-			// ハコからあふれたかどうかの判定
-			if (bodyA.id === this.overflowCollider.id || bodyB.id === this.overflowCollider.id) {
-				if (this.gameOverReadyBodyIds.includes(bodyA.id) || this.gameOverReadyBodyIds.includes(bodyB.id)) {
-					this.gameOver();
-					break;
-				}
-				continue;
-			}
-		}
-	}
+                        // ハコからあふれたかどうかの判定
+                        if (bodyA.id === this.overflowCollider.id || bodyB.id === this.overflowCollider.id) {
+                                const other = bodyA.id === this.overflowCollider.id ? bodyB : bodyA;
+                                if (this.gameOverReadyBodyIds.includes(other.id)) {
+                                        this.handleOverflow(other);
+                                        if (this.isGameOver) break;
+                                }
+                                continue;
+                        }
+                }
+        }
 
-	public surrender() {
-		this.logs.push({
-			frame: this.frame,
-			operation: 'surrender',
-		});
+        public surrender() {
+                this.logs.push({
+                        frame: this.frame,
+                        operation: 'surrender',
+                });
 
-		this.gameOver();
-	}
+                this.finalizeGameOver();
+        }
 
-	private gameOver() {
-		this.isGameOver = true;
-		this.emit('gameOver');
-	}
+       private handleOverflow(body: Matter.Body) {
+               if (this.lives > 1) {
+                       this.lives--;
+                       this.removeOverflowBodies();
+               } else {
+                       this.finalizeGameOver();
+               }
+       }
 
-	public start() {
-		for (let i = 0; i < this.STOCK_MAX; i++) {
-			this.stock.push({
+       private removeOverflowBodies() {
+               for (const b of [...this.engine.world.bodies]) {
+                       if (b.label === '_wall_' || b.label === '_overflow_') continue;
+                       if (b.bounds.min.y < 0) {
+                               this.fusionReadyBodyIds = this.fusionReadyBodyIds.filter(x => x !== b.id);
+                               this.gameOverReadyBodyIds = this.gameOverReadyBodyIds.filter(x => x !== b.id);
+                               Matter.Composite.remove(this.engine.world, b);
+                       }
+               }
+       }
+
+       private finalizeGameOver() {
+               this.removeOverflowBodies();
+               this.isGameOver = true;
+               this.emit('gameOver');
+       }
+
+        public start() {
+                this.emit('changeLives', this.lives);
+                for (let i = 0; i < this.STOCK_MAX; i++) {
+                        this.stock.push({
 				id: this.rng().toString(),
 				mono: this.monoDefinitions.filter(x => x.dropCandidate)[Math.floor(this.rng() * this.monoDefinitions.filter(x => x.dropCandidate).length)],
 			});


### PR DESCRIPTION
## 概要
- 次の落下物の横に残りライフを表示
- スコアボックスからライフ表示を削除
- あふれた際はライフを消費して上部のアイテムを除去し、ライフが尽きたらゲームオーバー

## テスト
- `pnpm -r lint` *(失敗: ネットワークに接続できず)*
