### PR TITLE
mkkey.net OAuth連携へ修正し招待コード免除フローを実装

### DIFF
--- a/packages/backend/migration/1738000000000-mkkeyAccountLink.js
+++ b/packages/backend/migration/1738000000000-mkkeyAccountLink.js
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export class MkkeyAccountLink1738000000000 {
+	name = 'MkkeyAccountLink1738000000000'
+
+	async up(queryRunner) {
+		await queryRunner.query(`CREATE TABLE "mkkey_account_link" ("id" SERIAL NOT NULL, "mkkeyUserId" character varying(128) NOT NULL, "mkkeyUsernameLower" character varying(128) NOT NULL, "userId" character varying(32) NOT NULL, "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_08defe7f3936a8058bc2a9993c8" PRIMARY KEY ("id"))`);
+		await queryRunner.query(`CREATE UNIQUE INDEX "IDX_mkkey_account_link_mkkey_user_id" ON "mkkey_account_link" ("mkkeyUserId") `);
+		await queryRunner.query(`CREATE UNIQUE INDEX "IDX_mkkey_account_link_mkkey_username_lower" ON "mkkey_account_link" ("mkkeyUsernameLower") `);
+		await queryRunner.query(`CREATE UNIQUE INDEX "IDX_mkkey_account_link_user_id" ON "mkkey_account_link" ("userId") `);
+		await queryRunner.query(`ALTER TABLE "mkkey_account_link" ADD CONSTRAINT "FK_mkkey_account_link_user_id" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+	}
+
+	async down(queryRunner) {
+		await queryRunner.query(`ALTER TABLE "mkkey_account_link" DROP CONSTRAINT "FK_mkkey_account_link_user_id"`);
+		await queryRunner.query(`DROP INDEX "public"."IDX_mkkey_account_link_user_id"`);
+		await queryRunner.query(`DROP INDEX "public"."IDX_mkkey_account_link_mkkey_username_lower"`);
+		await queryRunner.query(`DROP INDEX "public"."IDX_mkkey_account_link_mkkey_user_id"`);
+		await queryRunner.query(`DROP TABLE "mkkey_account_link"`);
+	}
+}

--- a/packages/backend/migration/1738000001000-addMkkeyToUserPending.js
+++ b/packages/backend/migration/1738000001000-addMkkeyToUserPending.js
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export class AddMkkeyToUserPending1738000001000 {
+	name = 'AddMkkeyToUserPending1738000001000'
+
+	async up(queryRunner) {
+		await queryRunner.query(`ALTER TABLE "user_pending" ADD "mkkeyUserId" character varying(128)`);
+		await queryRunner.query(`ALTER TABLE "user_pending" ADD "mkkeyUsernameLower" character varying(128)`);
+	}
+
+	async down(queryRunner) {
+		await queryRunner.query(`ALTER TABLE "user_pending" DROP COLUMN "mkkeyUsernameLower"`);
+		await queryRunner.query(`ALTER TABLE "user_pending" DROP COLUMN "mkkeyUserId"`);
+	}
+}

--- a/packages/backend/src/di-symbols.ts
+++ b/packages/backend/src/di-symbols.ts
@@ -64,6 +64,7 @@ export const DI = {
 	accessTokensRepository: Symbol('accessTokensRepository'),
 	signinsRepository: Symbol('signinsRepository'),
 	messagingMessagesRepository: Symbol('messagingMessagesRepository'),
+	mkkeyAccountLinksRepository: Symbol('mkkeyAccountLinksRepository'),
 	pagesRepository: Symbol('pagesRepository'),
 	pageLikesRepository: Symbol('pageLikesRepository'),
 	galleryPostsRepository: Symbol('galleryPostsRepository'),

--- a/packages/backend/src/models/MkkeyAccountLink.ts
+++ b/packages/backend/src/models/MkkeyAccountLink.ts
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Column, CreateDateColumn, Entity, Index, JoinColumn, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { MiUser } from './User.js';
+
+@Entity('mkkey_account_link')
+export class MiMkkeyAccountLink {
+	@PrimaryGeneratedColumn()
+	public id: number;
+
+	@Index({ unique: true })
+	@Column('varchar', {
+		length: 128,
+	})
+	public mkkeyUserId: string;
+
+	@Index({ unique: true })
+	@Column('varchar', {
+		length: 128,
+	})
+	public mkkeyUsernameLower: string;
+
+	@Index({ unique: true })
+	@Column('varchar', {
+		length: 32,
+	})
+	public userId: MiUser['id'];
+
+	@OneToOne(type => MiUser, {
+		onDelete: 'CASCADE',
+	})
+	@JoinColumn({ name: 'userId' })
+	public user: MiUser | null;
+
+	@CreateDateColumn({
+		type: 'timestamp with time zone',
+	})
+	public createdAt: Date;
+}

--- a/packages/backend/src/models/RepositoryModule.ts
+++ b/packages/backend/src/models/RepositoryModule.ts
@@ -38,6 +38,7 @@ import {
 	MiHashtag,
 	MiInstance,
 	MiMessagingMessage,
+	MiMkkeyAccountLink,
 	MiMeta,
 	MiModerationLog,
 	MiMuting,
@@ -364,6 +365,12 @@ const $messagingMessagesRepository: Provider = {
 	inject: [DI.db],
 };
 
+const $mkkeyAccountLinksRepository: Provider = {
+	provide: DI.mkkeyAccountLinksRepository,
+	useFactory: (db: DataSource) => db.getRepository(MiMkkeyAccountLink).extend(miRepository as MiRepository<MiMkkeyAccountLink>),
+	inject: [DI.db],
+};
+
 const $pagesRepository: Provider = {
 	provide: DI.pagesRepository,
 	useFactory: (db: DataSource) => db.getRepository(MiPage).extend(miRepository as MiRepository<MiPage>),
@@ -593,6 +600,7 @@ const $noteScheduleRepository: Provider = {
 		$accessTokensRepository,
 		$signinsRepository,
 		$messagingMessagesRepository,
+		$mkkeyAccountLinksRepository,
 		$pagesRepository,
 		$pageLikesRepository,
 		$galleryPostsRepository,
@@ -671,6 +679,7 @@ const $noteScheduleRepository: Provider = {
 		$accessTokensRepository,
 		$signinsRepository,
 		$messagingMessagesRepository,
+		$mkkeyAccountLinksRepository,
 		$pagesRepository,
 		$pageLikesRepository,
 		$galleryPostsRepository,

--- a/packages/backend/src/models/UserPending.ts
+++ b/packages/backend/src/models/UserPending.ts
@@ -31,4 +31,14 @@ export class MiUserPending {
 		length: 128,
 	})
 	public password: string;
+
+	@Column('varchar', {
+		length: 128, nullable: true,
+	})
+	public mkkeyUserId: string | null;
+
+	@Column('varchar', {
+		length: 128, nullable: true,
+	})
+	public mkkeyUsernameLower: string | null;
 }

--- a/packages/backend/src/models/_.ts
+++ b/packages/backend/src/models/_.ts
@@ -38,6 +38,7 @@ import { MiGalleryPost } from '@/models/GalleryPost.js';
 import { MiHashtag } from '@/models/Hashtag.js';
 import { MiInstance } from '@/models/Instance.js';
 import { MiMessagingMessage } from '@/models/MessagingMessage.js';
+import { MiMkkeyAccountLink } from '@/models/MkkeyAccountLink.js';
 import { MiMeta } from '@/models/Meta.js';
 import { MiModerationLog } from '@/models/ModerationLog.js';
 import { MiMuting } from '@/models/Muting.js';
@@ -160,6 +161,7 @@ export {
 	MiHashtag,
 	MiInstance,
 	MiMessagingMessage,
+	MiMkkeyAccountLink,
 	MiMeta,
 	MiModerationLog,
 	MiMuting,
@@ -238,6 +240,7 @@ export type GalleryPostsRepository = Repository<MiGalleryPost> & MiRepository<Mi
 export type HashtagsRepository = Repository<MiHashtag> & MiRepository<MiHashtag>;
 export type InstancesRepository = Repository<MiInstance> & MiRepository<MiInstance>;
 export type MessagingMessagesRepository = Repository<MiMessagingMessage> & MiRepository<MiMessagingMessage>;
+export type MkkeyAccountLinksRepository = Repository<MiMkkeyAccountLink> & MiRepository<MiMkkeyAccountLink>;
 export type MetasRepository = Repository<MiMeta> & MiRepository<MiMeta>;
 export type ModerationLogsRepository = Repository<MiModerationLog> & MiRepository<MiModerationLog>;
 export type MutingsRepository = Repository<MiMuting> & MiRepository<MiMuting>;

--- a/packages/backend/src/postgres.ts
+++ b/packages/backend/src/postgres.ts
@@ -37,6 +37,7 @@ import { MiGalleryPost } from '@/models/GalleryPost.js';
 import { MiHashtag } from '@/models/Hashtag.js';
 import { MiInstance } from '@/models/Instance.js';
 import { MiMessagingMessage } from '@/models/MessagingMessage.js';
+import { MiMkkeyAccountLink } from '@/models/MkkeyAccountLink.js';
 import { MiMeta } from '@/models/Meta.js';
 import { MiModerationLog } from '@/models/ModerationLog.js';
 import { MiMuting } from '@/models/Muting.js';
@@ -185,6 +186,7 @@ export const entities = [
 	MiAbuseReportNotificationRecipient,
 	MiRegistrationTicket,
 	MiMessagingMessage,
+	MiMkkeyAccountLink,
 	MiSignin,
 	MiModerationLog,
 	MiClip,

--- a/packages/backend/src/server/ServerModule.ts
+++ b/packages/backend/src/server/ServerModule.ts
@@ -50,6 +50,7 @@ import { ReversiChannelService } from './api/stream/channels/reversi.js';
 import { ReversiGameChannelService } from './api/stream/channels/reversi-game.js';
 import { SigninWithPasskeyApiService } from './api/SigninWithPasskeyApiService.js';
 import { BubbleTimelineChannelService } from './api/stream/channels/bubble-timeline.js';
+import { MkkeySsoApiService } from './api/MkkeySsoApiService.js';
 import { InboxProcessorService } from '@/queue/processors/InboxProcessorService.js';
 import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
 
@@ -80,6 +81,7 @@ import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
 		SigninWithPasskeyApiService,
 		SigninService,
 		SignupApiService,
+		MkkeySsoApiService,
 		StreamingApiServerService,
 		MainChannelService,
 		AdminChannelService,

--- a/packages/backend/src/server/api/ApiServerService.ts
+++ b/packages/backend/src/server/api/ApiServerService.ts
@@ -19,6 +19,7 @@ import { ApiCallService } from './ApiCallService.js';
 import { SignupApiService } from './SignupApiService.js';
 import { SigninApiService } from './SigninApiService.js';
 import { SigninWithPasskeyApiService } from './SigninWithPasskeyApiService.js';
+import { MkkeySsoApiService } from './MkkeySsoApiService.js';
 import type { FastifyInstance, FastifyPluginOptions } from 'fastify';
 
 @Injectable()
@@ -40,6 +41,7 @@ export class ApiServerService {
 		private signupApiService: SignupApiService,
 		private signinApiService: SigninApiService,
 		private signinWithPasskeyApiService: SigninWithPasskeyApiService,
+		private mkkeySsoApiService: MkkeySsoApiService,
 	) {
 		//this.createServer = this.createServer.bind(this);
 	}
@@ -115,6 +117,7 @@ export class ApiServerService {
 				host?: string;
 				invitationCode?: string;
 				emailAddress?: string;
+				mkkeyOauthToken?: string;
 				'hcaptcha-response'?: string;
 				'g-recaptcha-response'?: string;
 				'turnstile-response'?: string;
@@ -145,6 +148,13 @@ export class ApiServerService {
 		}>('/signin-with-passkey', (request, reply) => this.signinWithPasskeyApiService.signin(request, reply));
 
 		fastify.post<{ Body: { code: string; } }>('/signup-pending', (request, reply) => this.signupApiService.signupPending(request, reply));
+
+
+		fastify.post<{ Body: { mode: 'signin' | 'signup'; } }>('/mkkey-sso/authorize-url', (request, reply) => this.mkkeySsoApiService.getAuthorizeUrl(request));
+
+		fastify.get<{ Querystring: { code?: string; state?: string; }; }>('/mkkey-sso/callback', (request, reply) => this.mkkeySsoApiService.callback(request, reply));
+
+		fastify.post<{ Body: { oauthToken: string; } }>('/mkkey-sso/signin', (request, reply) => this.mkkeySsoApiService.signin(request, reply));
 
 		fastify.get('/v1/instance/peers', async (request, reply) => {
 			const instances = await this.instancesRepository.find({

--- a/packages/backend/src/server/api/MkkeySsoApiService.ts
+++ b/packages/backend/src/server/api/MkkeySsoApiService.ts
@@ -1,0 +1,226 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { Inject, Injectable } from '@nestjs/common';
+import { DI } from '@/di-symbols.js';
+import type { MkkeyAccountLinksRepository } from '@/models/_.js';
+import type { Config } from '@/config.js';
+import { FastifyReplyError } from '@/misc/fastify-reply-error.js';
+import type { MiLocalUser } from '@/models/User.js';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { SigninService } from './SigninService.js';
+
+type MkkeyMeResponse = {
+	id?: string;
+	username?: string;
+};
+
+type MkkeyMode = 'signin' | 'signup';
+
+type MkkeyStatePayload = {
+	mode: MkkeyMode;
+	exp: number;
+};
+
+type MkkeyOauthPayload = {
+	mkkeyUserId: string;
+	mkkeyUsernameLower: string;
+	exp: number;
+};
+
+@Injectable()
+export class MkkeySsoApiService {
+	constructor(
+		@Inject(DI.config)
+		private config: Config,
+
+		@Inject(DI.mkkeyAccountLinksRepository)
+		private mkkeyAccountLinksRepository: MkkeyAccountLinksRepository,
+
+		private signinService: SigninService,
+	) {
+	}
+
+	private get signingSecret(): string {
+		return process.env.MKKEY_OAUTH_SIGNING_SECRET ?? this.config.id;
+	}
+
+	private get clientId(): string {
+		const value = process.env.MKKEY_OAUTH_CLIENT_ID;
+		if (!value) throw new FastifyReplyError(500, 'MKKEY_OAUTH_CLIENT_ID_NOT_CONFIGURED');
+		return value;
+	}
+
+	private get clientSecret(): string {
+		const value = process.env.MKKEY_OAUTH_CLIENT_SECRET;
+		if (!value) throw new FastifyReplyError(500, 'MKKEY_OAUTH_CLIENT_SECRET_NOT_CONFIGURED');
+		return value;
+	}
+
+	private get redirectUri(): string {
+		return process.env.MKKEY_OAUTH_REDIRECT_URI ?? `${this.config.apiUrl}/mkkey-sso/callback`;
+	}
+
+	private get authorizeEndpoint(): string {
+		return process.env.MKKEY_OAUTH_AUTHORIZE_URL ?? 'https://mkkey.net/oauth/authorize';
+	}
+
+	private get tokenEndpoint(): string {
+		return process.env.MKKEY_OAUTH_TOKEN_URL ?? 'https://mkkey.net/oauth/token';
+	}
+
+	private get meEndpoint(): string {
+		return process.env.MKKEY_OAUTH_ME_URL ?? 'https://mkkey.net/api/i';
+	}
+
+	private signPayload(payload: object): string {
+		const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+		const signature = createHmac('sha256', this.signingSecret).update(encodedPayload).digest('base64url');
+		return `${encodedPayload}.${signature}`;
+	}
+
+	private verifyPayload<T>(token: string): T {
+		const [encodedPayload, signature] = token.split('.');
+		if (!encodedPayload || !signature) throw new FastifyReplyError(400, 'INVALID_MKKEY_TOKEN');
+
+		const expected = createHmac('sha256', this.signingSecret).update(encodedPayload).digest('base64url');
+		const sigBuffer = Buffer.from(signature);
+		const expectedBuffer = Buffer.from(expected);
+		if (sigBuffer.length !== expectedBuffer.length || !timingSafeEqual(sigBuffer, expectedBuffer)) {
+			throw new FastifyReplyError(400, 'INVALID_MKKEY_TOKEN');
+		}
+
+		return JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf-8')) as T;
+	}
+
+	private async fetchMkkeyUser(accessToken: string): Promise<{ id: string; usernameLower: string; }> {
+		const meRes = await fetch(this.meEndpoint, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ i: accessToken }),
+		}).catch(() => {
+			throw new FastifyReplyError(400, 'MKKEY_AUTH_FAILED');
+		});
+
+		if (!meRes.ok) throw new FastifyReplyError(400, 'MKKEY_AUTH_FAILED');
+
+		const me = await meRes.json() as MkkeyMeResponse;
+		if (!me.id || !me.username) throw new FastifyReplyError(400, 'MKKEY_AUTH_FAILED');
+
+		return {
+			id: me.id,
+			usernameLower: me.username.toLowerCase(),
+		};
+	}
+
+	public createAuthorizeUrl(mode: MkkeyMode): string {
+		const state = this.signPayload({
+			mode,
+			exp: Date.now() + (1000 * 60 * 10),
+		} satisfies MkkeyStatePayload);
+
+		const params = new URLSearchParams({
+			response_type: 'code',
+			client_id: this.clientId,
+			redirect_uri: this.redirectUri,
+			scope: 'read:account',
+			state,
+		});
+
+		return `${this.authorizeEndpoint}?${params.toString()}`;
+	}
+
+	public getAuthorizeUrl(request: FastifyRequest<{ Body: { mode: MkkeyMode; } }>) {
+		const mode = request.body.mode;
+		if (mode !== 'signin' && mode !== 'signup') throw new FastifyReplyError(400, 'INVALID_MODE');
+		return {
+			url: this.createAuthorizeUrl(mode),
+		};
+	}
+
+	public async callback(request: FastifyRequest<{ Querystring: { code?: string; state?: string; }; }>, reply: FastifyReply) {
+		const code = request.query.code;
+		const state = request.query.state;
+		if (!code || !state) throw new FastifyReplyError(400, 'INVALID_OAUTH_CALLBACK');
+
+		const statePayload = this.verifyPayload<MkkeyStatePayload>(state);
+		if (statePayload.exp < Date.now()) throw new FastifyReplyError(400, 'MKKEY_STATE_EXPIRED');
+
+		const tokenRes = await fetch(this.tokenEndpoint, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				grant_type: 'authorization_code',
+				code,
+				client_id: this.clientId,
+				client_secret: this.clientSecret,
+				redirect_uri: this.redirectUri,
+			}),
+		}).catch(() => {
+			throw new FastifyReplyError(400, 'MKKEY_TOKEN_EXCHANGE_FAILED');
+		});
+
+		if (!tokenRes.ok) throw new FastifyReplyError(400, 'MKKEY_TOKEN_EXCHANGE_FAILED');
+		const tokenBody = await tokenRes.json() as { access_token?: string; };
+		if (!tokenBody.access_token) throw new FastifyReplyError(400, 'MKKEY_TOKEN_EXCHANGE_FAILED');
+
+		const mkkeyUser = await this.fetchMkkeyUser(tokenBody.access_token);
+		const oauthToken = this.signPayload({
+			mkkeyUserId: mkkeyUser.id,
+			mkkeyUsernameLower: mkkeyUser.usernameLower,
+			exp: Date.now() + (1000 * 60 * 10),
+		} satisfies MkkeyOauthPayload);
+
+		reply.type('text/html; charset=utf-8');
+		return `<!doctype html><html><body><script>
+			window.opener?.postMessage(${JSON.stringify({ source: 'mkkey-sso', mode: statePayload.mode, oauthToken })}, '*');
+			window.close();
+		</script></body></html>`;
+	}
+
+	public verifyOauthToken(token: string): { mkkeyUserId: string; mkkeyUsernameLower: string; } {
+		const payload = this.verifyPayload<MkkeyOauthPayload>(token);
+		if (payload.exp < Date.now()) throw new FastifyReplyError(400, 'MKKEY_OAUTH_TOKEN_EXPIRED');
+		if (!payload.mkkeyUserId || !payload.mkkeyUsernameLower) throw new FastifyReplyError(400, 'INVALID_MKKEY_OAUTH_TOKEN');
+		return {
+			mkkeyUserId: payload.mkkeyUserId,
+			mkkeyUsernameLower: payload.mkkeyUsernameLower,
+		};
+	}
+
+	public async findLinkedUser(payload: { mkkeyUserId: string; mkkeyUsernameLower: string; }): Promise<MiLocalUser | null> {
+		const link = await this.mkkeyAccountLinksRepository.findOne({
+			where: [{ mkkeyUserId: payload.mkkeyUserId }, { mkkeyUsernameLower: payload.mkkeyUsernameLower }],
+			relations: ['user'],
+		});
+
+		if (!link?.user) return null;
+		return link.user as MiLocalUser;
+	}
+
+	public async saveLink(payload: { mkkeyUserId: string; mkkeyUsernameLower: string; userId: string; }): Promise<void> {
+		await this.mkkeyAccountLinksRepository.insert({
+			mkkeyUserId: payload.mkkeyUserId,
+			mkkeyUsernameLower: payload.mkkeyUsernameLower,
+			userId: payload.userId,
+		});
+	}
+
+	public async signin(request: FastifyRequest<{ Body: { oauthToken: string; } }>, reply: FastifyReply) {
+		const oauthToken = request.body.oauthToken;
+		if (typeof oauthToken !== 'string' || oauthToken.length === 0) throw new FastifyReplyError(400, 'NO_MKKEY_OAUTH_TOKEN');
+
+		const payload = this.verifyOauthToken(oauthToken);
+		const user = await this.findLinkedUser(payload);
+		if (!user) throw new FastifyReplyError(404, 'MKKEY_ACCOUNT_NOT_LINKED');
+
+		return this.signinService.signin(request, reply, user);
+	}
+}

--- a/packages/backend/src/server/api/SignupApiService.ts
+++ b/packages/backend/src/server/api/SignupApiService.ts
@@ -20,6 +20,7 @@ import { FastifyReplyError } from '@/misc/fastify-reply-error.js';
 import { bindThis } from '@/decorators.js';
 import { L_CHARS, secureRndstr } from '@/misc/secure-rndstr.js';
 import { SigninService } from './SigninService.js';
+import { MkkeySsoApiService } from './MkkeySsoApiService.js';
 import type { FastifyRequest, FastifyReply } from 'fastify';
 
 @Injectable()
@@ -51,6 +52,7 @@ export class SignupApiService {
 		private captchaService: CaptchaService,
 		private signupService: SignupService,
 		private signinService: SigninService,
+		private mkkeySsoApiService: MkkeySsoApiService,
 		private emailService: EmailService,
 	) {
 	}
@@ -64,6 +66,7 @@ export class SignupApiService {
 				host?: string;
 				invitationCode?: string;
 				emailAddress?: string;
+				mkkeyOauthToken?: string;
 				'hcaptcha-response'?: string;
 				'g-recaptcha-response'?: string;
 				'turnstile-response'?: string;
@@ -75,8 +78,6 @@ export class SignupApiService {
 	) {
 		const body = request.body;
 
-		// Verify *Captcha
-		// ただしテスト時はこの機構は障害となるため無効にする
 		if (process.env.NODE_ENV !== 'test') {
 			if (this.meta.enableHcaptcha && this.meta.hcaptchaSecretKey) {
 				await this.captchaService.verifyHcaptcha(this.meta.hcaptchaSecretKey, body['hcaptcha-response']).catch(err => {
@@ -114,6 +115,18 @@ export class SignupApiService {
 		const host: string | null = process.env.NODE_ENV === 'test' ? (body['host'] ?? null) : null;
 		const invitationCode = body['invitationCode'];
 		const emailAddress = body['emailAddress'];
+		const mkkeyOauthToken = body['mkkeyOauthToken'];
+
+		const mkkeyIdentity = typeof mkkeyOauthToken === 'string' && mkkeyOauthToken.length > 0
+			? this.mkkeySsoApiService.verifyOauthToken(mkkeyOauthToken)
+			: null;
+
+		if (mkkeyIdentity) {
+			const linkedUser = await this.mkkeySsoApiService.findLinkedUser(mkkeyIdentity);
+			if (linkedUser) {
+				return this.signinService.signin(request, reply, linkedUser);
+			}
+		}
 
 		if (this.meta.emailRequiredForSignup) {
 			if (emailAddress == null || typeof emailAddress !== 'string') {
@@ -131,39 +144,40 @@ export class SignupApiService {
 		let ticket: MiRegistrationTicket | null = null;
 
 		if (this.meta.disableRegistration) {
-			if (invitationCode == null || typeof invitationCode !== 'string') {
+			if ((invitationCode == null || typeof invitationCode !== 'string') && !mkkeyIdentity) {
 				reply.code(400);
 				return;
 			}
 
-			ticket = await this.registrationTicketsRepository.findOneBy({
-				code: invitationCode,
-			});
+			if (invitationCode != null && typeof invitationCode === 'string') {
+				ticket = await this.registrationTicketsRepository.findOneBy({
+					code: invitationCode,
+				});
+			}
 
-			if (ticket == null || ticket.usedById != null) {
+			if (!mkkeyIdentity) {
+				if (ticket == null || ticket.usedById != null) {
+					reply.code(400);
+					return;
+				}
+			}
+
+			if (ticket && ticket.expiresAt && ticket.expiresAt < new Date()) {
 				reply.code(400);
 				return;
 			}
 
-			if (ticket.expiresAt && ticket.expiresAt < new Date()) {
-				reply.code(400);
-				return;
-			}
-
-			// メアド認証が有効の場合
-			if (this.meta.emailRequiredForSignup) {
-				// メアド認証済みならエラー
+			if (ticket && this.meta.emailRequiredForSignup) {
 				if (ticket.usedBy) {
 					reply.code(400);
 					return;
 				}
 
-				// 認証しておらず、メール送信から30分以内ならエラー
 				if (ticket.usedAt && ticket.usedAt.getTime() + (1000 * 60 * 30) > Date.now()) {
 					reply.code(400);
 					return;
 				}
-			} else if (ticket.usedAt) {
+			} else if (ticket && ticket.usedAt) {
 				reply.code(400);
 				return;
 			}
@@ -174,7 +188,6 @@ export class SignupApiService {
 				throw new FastifyReplyError(400, 'DUPLICATED_USERNAME');
 			}
 
-			// Check deleted username duplication
 			if (await this.usedUsernamesRepository.exists({ where: { username: username.toLowerCase() } })) {
 				throw new FastifyReplyError(400, 'USED_USERNAME');
 			}
@@ -185,17 +198,16 @@ export class SignupApiService {
 			}
 
 			const code = secureRndstr(16, { chars: L_CHARS });
-
-			// Generate hash of password
-			//const salt = await bcrypt.genSalt(8);
 			const hash = await argon2.hash(password);
 
 			const pendingUser = await this.userPendingsRepository.insertOne({
 				id: this.idService.gen(),
 				code,
 				email: emailAddress!,
-				username: username,
+				username,
 				password: hash,
+				mkkeyUserId: mkkeyIdentity?.mkkeyUserId ?? null,
+				mkkeyUsernameLower: mkkeyIdentity?.mkkeyUsernameLower ?? null,
 			});
 
 			const link = `${this.config.url}/signup-complete/${code}`;
@@ -213,39 +225,46 @@ export class SignupApiService {
 
 			reply.code(204);
 			return;
-		} else {
-			try {
-				const { account, secret } = await this.signupService.signup({
-					username, password, host,
+		}
+
+		try {
+			const { account, secret } = await this.signupService.signup({
+				username, password, host,
+			});
+
+			const res = await this.userEntityService.pack(account, account, {
+				schema: 'MeDetailed',
+				includeSecrets: true,
+			});
+
+			if (mkkeyIdentity) {
+				await this.mkkeySsoApiService.saveLink({
+					mkkeyUserId: mkkeyIdentity.mkkeyUserId,
+					mkkeyUsernameLower: mkkeyIdentity.mkkeyUsernameLower,
+					userId: account.id,
 				});
-
-				const res = await this.userEntityService.pack(account, account, {
-					schema: 'MeDetailed',
-					includeSecrets: true,
-				});
-
-				if (ticket) {
-					await this.registrationTicketsRepository.update(ticket.id, {
-						usedAt: new Date(),
-						usedBy: account,
-						usedById: account.id,
-					});
-				}
-
-				return {
-					...res,
-					token: secret,
-				};
-			} catch (err) {
-				throw new FastifyReplyError(400, typeof err === 'string' ? err : (err as Error).toString());
 			}
+
+			if (ticket) {
+				await this.registrationTicketsRepository.update(ticket.id, {
+					usedAt: new Date(),
+					usedBy: account,
+					usedById: account.id,
+				});
+			}
+
+			return {
+				...res,
+				token: secret,
+			};
+		} catch (err) {
+			throw new FastifyReplyError(400, typeof err === 'string' ? err : (err as Error).toString());
 		}
 	}
 
 	@bindThis
 	public async signupPending(request: FastifyRequest<{ Body: { code: string; } }>, reply: FastifyReply) {
 		const body = request.body;
-
 		const code = body['code'];
 
 		try {
@@ -255,7 +274,7 @@ export class SignupApiService {
 				throw new FastifyReplyError(400, 'EXPIRED');
 			}
 
-			const { account, secret } = await this.signupService.signup({
+			const { account } = await this.signupService.signup({
 				username: pendingUser.username,
 				passwordHash: pendingUser.password,
 			});
@@ -271,6 +290,14 @@ export class SignupApiService {
 				emailVerified: true,
 				emailVerifyCode: null,
 			});
+
+			if (pendingUser.mkkeyUserId && pendingUser.mkkeyUsernameLower) {
+				await this.mkkeySsoApiService.saveLink({
+					mkkeyUserId: pendingUser.mkkeyUserId,
+					mkkeyUsernameLower: pendingUser.mkkeyUsernameLower,
+					userId: account.id,
+				});
+			}
 
 			const ticket = await this.registrationTicketsRepository.findOneBy({ pendingUserId: pendingUser.id });
 			if (ticket) {

--- a/packages/frontend/src/components/MkSignin.input.vue
+++ b/packages/frontend/src/components/MkSignin.input.vue
@@ -39,6 +39,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<MkButton type="submit" large primary rounded style="margin: 0 auto;" data-cy-signin-page-input-continue>{{ i18n.ts.continue }} <i class="ti ti-arrow-right"></i></MkButton>
 		</form>
 
+		<MkButton type="button" rounded style="margin: 0 auto;" @click="signinWithMkkeySso">mkkey.net でログイン</MkButton>
+
 		<!-- パスワードレスログイン -->
 		<div :class="$style.orHr">
 			<p :class="$style.orMsg">{{ i18n.ts.or }}</p>
@@ -57,15 +59,22 @@ import { ref } from 'vue';
 import { toUnicode } from 'punycode/';
 
 import { query, extractDomain } from '@@/js/url.js';
-import { host as configHost } from '@@/js/config.js';
+import { apiUrl, host as configHost } from '@@/js/config.js';
 import type { OpenOnRemoteOptions } from '@/scripts/please-login.js';
 import { i18n } from '@/i18n.js';
+import { login } from '@/account.js';
 import * as os from '@/os.js';
 import { defaultStore } from '@/store.js';
 
 import MkButton from '@/components/MkButton.vue';
 import MkInput from '@/components/MkInput.vue';
 import MkInfo from '@/components/MkInfo.vue';
+
+type MkkeySsoMessage = {
+	source: 'mkkey-sso';
+	mode: 'signin' | 'signup';
+	oauthToken: string;
+};
 
 const props = withDefaults(defineProps<{
 	message?: string,
@@ -83,6 +92,44 @@ const emit = defineEmits<{
 const host = toUnicode(configHost);
 
 const username = ref('');
+
+function isMkkeySsoMessage(data: unknown): data is MkkeySsoMessage {
+	if (typeof data !== 'object' || data == null) return false;
+	const payload = data as Record<string, unknown>;
+	return payload.source === 'mkkey-sso' && typeof payload.oauthToken === 'string' && (payload.mode === 'signin' || payload.mode === 'signup');
+}
+
+async function runMkkeyOauth(mode: 'signin' | 'signup'): Promise<string | null> {
+	const res = await fetch(`${apiUrl}/mkkey-sso/authorize-url`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({ mode }),
+	});
+
+	if (!res.ok) return null;
+	const body = await res.json() as { url: string; };
+	const popup = window.open(body.url, 'mkkey-sso', 'width=520,height=700');
+	if (!popup) return null;
+
+	return await new Promise((resolve) => {
+		const timer = setTimeout(() => {
+			window.removeEventListener('message', onMessage);
+			resolve(null);
+		}, 1000 * 60 * 3);
+
+		const onMessage = (event: MessageEvent<unknown>) => {
+			if (!isMkkeySsoMessage(event.data)) return;
+			if (event.data.mode !== mode) return;
+			clearTimeout(timer);
+			window.removeEventListener('message', onMessage);
+			resolve(event.data.oauthToken);
+		};
+
+		window.addEventListener('message', onMessage);
+	});
+}
 
 //#region Open on remote
 function openRemote(options: OpenOnRemoteOptions, targetHost?: string): void {
@@ -139,6 +186,36 @@ async function specifyHostAndOpenRemote(options: OpenOnRemoteOptions): Promise<v
 		return;
 	}
 	openRemote(options, targetHost);
+}
+
+async function signinWithMkkeySso(): Promise<void> {
+	const oauthToken = await runMkkeyOauth('signin');
+	if (!oauthToken) {
+		os.alert({
+			type: 'error',
+			text: 'mkkey.net OAuthに失敗しました。',
+		});
+		return;
+	}
+
+	const res = await fetch(`${apiUrl}/mkkey-sso/signin`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({ oauthToken }),
+	});
+
+	if (!res.ok) {
+		os.alert({
+			type: 'error',
+			text: 'mkkey.net連携済みのアカウントが見つかりませんでした。',
+		});
+		return;
+	}
+
+	const body = await res.json() as { i: string; };
+	await login(body.i);
 }
 //#endregion
 </script>

--- a/packages/frontend/src/components/MkSignupDialog.form.vue
+++ b/packages/frontend/src/components/MkSignupDialog.form.vue
@@ -10,7 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 	</div>
 	<MkSpacer :marginMin="20" :marginMax="32">
 		<form class="_gaps_m" autocomplete="new-password" @submit.prevent="onSubmit">
-			<MkInput v-if="instance.disableRegistration" v-model="invitationCode" type="text" :spellcheck="false" required>
+			<MkInput v-if="instance.disableRegistration && !mkkeyOauthToken" v-model="invitationCode" type="text" :spellcheck="false" required>
 				<template #label>{{ i18n.ts.invitationCode }}</template>
 				<template #prefix><i class="ti ti-key"></i></template>
 			</MkInput>
@@ -69,6 +69,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<MkCaptcha v-if="instance.enableTestcaptcha" ref="testcaptcha" v-model="testcaptchaResponse" :class="$style.captcha" provider="testcaptcha"/>
 			<div class="_buttonsCenter">
 				<MkButton inline rounded @click="goBack"><i class="ti ti-arrow-left"></i> {{ i18n.ts.goBack }}</MkButton>
+				<MkButton inline rounded type="button" @click="signupWithMkkeySso">mkkey.net でログイン</MkButton>
 				<MkButton type="submit" :disabled="shouldDisableSubmitting" inline gradate rounded data-cy-signup-submit>
 					<template v-if="submitting">
 						<MkLoading :em="true" :colored="false"/>
@@ -85,6 +86,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 import { ref, computed } from 'vue';
 import { toUnicode } from 'punycode/';
 import * as Misskey from 'cherrypick-js';
+import { apiUrl } from '@@/js/config.js';
 import * as config from '@@/js/config.js';
 import MkButton from './MkButton.vue';
 import MkInput from './MkInput.vue';
@@ -94,6 +96,12 @@ import { misskeyApi } from '@/scripts/misskey-api.js';
 import { login } from '@/account.js';
 import { instance } from '@/instance.js';
 import { i18n } from '@/i18n.js';
+
+type MkkeySsoMessage = {
+	source: 'mkkey-sso';
+	mode: 'signin' | 'signup';
+	oauthToken: string;
+};
 
 const props = withDefaults(defineProps<{
 	autoSet?: boolean;
@@ -119,6 +127,7 @@ const username = ref<string>('');
 const password = ref<string>('');
 const retypedPassword = ref<string>('');
 const invitationCode = ref<string>('');
+const mkkeyOauthToken = ref<string>('');
 const email = ref('');
 const usernameState = ref<null | 'wait' | 'ok' | 'unavailable' | 'error' | 'invalid-format' | 'min-range' | 'max-range'>(null);
 const emailState = ref<null | 'wait' | 'ok' | 'unavailable:used' | 'unavailable:format' | 'unavailable:disposable' | 'unavailable:banned' | 'unavailable:mx' | 'unavailable:smtp' | 'unavailable' | 'error'>(null);
@@ -265,15 +274,71 @@ function goBack() {
 	emit('back');
 }
 
+function isMkkeySsoMessage(data: unknown): data is MkkeySsoMessage {
+	if (typeof data !== 'object' || data == null) return false;
+	const payload = data as Record<string, unknown>;
+	return payload.source === 'mkkey-sso' && typeof payload.oauthToken === 'string' && (payload.mode === 'signin' || payload.mode === 'signup');
+}
+
+async function runMkkeyOauth(mode: 'signin' | 'signup'): Promise<string | null> {
+	const res = await fetch(`${apiUrl}/mkkey-sso/authorize-url`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({ mode }),
+	});
+
+	if (!res.ok) return null;
+	const body = await res.json() as { url: string; };
+	const popup = window.open(body.url, 'mkkey-sso', 'width=520,height=700');
+	if (!popup) return null;
+
+	return await new Promise((resolve) => {
+		const timer = setTimeout(() => {
+			window.removeEventListener('message', onMessage);
+			resolve(null);
+		}, 1000 * 60 * 3);
+
+		const onMessage = (event: MessageEvent<unknown>) => {
+			if (!isMkkeySsoMessage(event.data)) return;
+			if (event.data.mode !== mode) return;
+			clearTimeout(timer);
+			window.removeEventListener('message', onMessage);
+			resolve(event.data.oauthToken);
+		};
+
+		window.addEventListener('message', onMessage);
+	});
+}
+
+async function signupWithMkkeySso(): Promise<void> {
+	const oauthToken = await runMkkeyOauth('signup');
+	if (!oauthToken) {
+		os.alert({
+			type: 'error',
+			text: 'mkkey.net OAuthに失敗しました。',
+		});
+		return;
+	}
+
+	mkkeyOauthToken.value = oauthToken;
+	os.alert({
+		type: 'success',
+		text: 'mkkey.net連携を確認しました。招待コードなしで登録できます。',
+	});
+}
+
 async function onSubmit(): Promise<void> {
 	if (submitting.value) return;
 	submitting.value = true;
 
-	const signupPayload: Misskey.entities.SignupRequest = {
+	const signupPayload: Misskey.entities.SignupRequest & { mkkeyOauthToken?: string; } = {
 		username: username.value,
 		password: password.value,
 		emailAddress: email.value,
 		invitationCode: invitationCode.value,
+		mkkeyOauthToken: mkkeyOauthToken.value || undefined,
 		'hcaptcha-response': hCaptchaResponse.value,
 		'm-captcha-response': mCaptchaResponse.value,
 		'g-recaptcha-response': reCaptchaResponse.value,


### PR DESCRIPTION
### Motivation
- mkkey.net 連携をセキュアな OAuth フローに置き換え、手入力トークン方式を廃止するため。 
- 自動でローカルアカウントを作成せず、招待コードのみを免除して利用者は自分で `username`/`password` を決められるようにするため。 
- フロントの表記を要望どおり `mkkey.net でログイン` に統一するため。 

### Description
- バックエンドに `MkkeySsoApiService`（OAuth フロー対応）を追加し、`POST /api/mkkey-sso/authorize-url`、`GET /api/mkkey-sso/callback`、`POST /api/mkkey-sso/signin` を実装した。 
- サインアップ処理を変更し `mkkeyOauthToken` を受け取れるようにして、`disableRegistration` が有効な場合でも mkkey OAuth 成功者のみ招待コードを免除するロジックにした（自動アカウント作成は行わない）。 
- mkkey とローカルアカウントの永続的紐付け用エンティティ `MiMkkeyAccountLink` とテーブルを追加し、`user_pending` にも `mkkeyUserId` / `mkkeyUsernameLower` カラムを追加してメール認証フロー経由でも紐付け可能にした。 
- フロント側のサインイン／サインアップUIを修正し、ボタン文言を `mkkey.net でログイン` に統一し、OAuth ポップアップ→`postMessage`→サーバーの `/mkkey-sso/signin` 呼び出しでのログインや、サインアップ時に `mkkeyOauthToken` を同梱する挙動を追加した。 
- 実装に伴い環境変数 `MKKEY_OAUTH_CLIENT_ID` / `MKKEY_OAUTH_CLIENT_SECRET` 等によるクライアント設定および短期署名トークンのための `MKKEY_OAUTH_SIGNING_SECRET`（未設定時はインスタンスIDを既定値）が利用されるようにした。 

### Testing
- 変更箇所に限定した型チェックとして `pnpm -w exec tsc -p packages/backend/tsconfig.json --noEmit 2>&1 | rg -n "MkkeySsoApiService|SignupApiService|ApiServerService|UserPending|mkkey"` を実行し、変更対象に紐づく型エラーは検出されなかった。 
- フロント側の変更箇所に限定した型チェックとして `pnpm -w exec tsc -p packages/frontend/tsconfig.json --noEmit 2>&1 | rg -n "MkSignin.input|MkSignupDialog.form|mkkey"` を実行し、変更対象に紐づく型エラーは検出されなかった。 
- UI のヘッドレス確認を試みるため Playwright スクリプトを実行したが、ローカルサーバーが起動しておらずページ遷移に失敗したためスクリーンショット取得は行えていない（`ERR_EMPTY_RESPONSE`）。 

注: リポジトリ全体には既存の型エラーや ESLint 設定依存の問題が残るため、上記は「変更対象に限定した」静的チェック結果である点に留意してください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699016d8be508326a15ad0c6a502fd0b)